### PR TITLE
add docs to rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ This roster is seeded with all approvers from Eventing workgroups.
 
 | Release | Release Date | Serving        | Eventing        | Docs          | Unpin repos | PKG cut    |
 | ------- | ------------ | -------------- | --------------- | -----------   | ----------- | ---------- |
-| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        | -             | -           | 2020-08-11 |
-| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        | -             | 2020-08-19  | 2020-09-22 |
-| v0.19   | 2020-11-10   | julz           | n3wscott        | -             | 2020-09-30  | 2020-11-03 |
-| v0.20   | 2021-01-12   | nak3           | slinkydeveloper | -             | 2020-11-11  | 2021-01-07 |
+| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        | richieescarez | -           | 2020-08-11 |
+| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        | richieescarez | 2020-08-19  | 2020-09-22 |
+| v0.19   | 2020-11-10   | julz           | n3wscott        | richieescarez | 2020-09-30  | 2020-11-03 |
+| v0.20   | 2021-01-12   | nak3           | slinkydeveloper | richieescarez | 2020-11-11  | 2021-01-07 |
 | v0.21   | 2021-02-23   | mattmoor       | lionelvillard   | csantanapr    | 2021-01-13  | 2021-02-16 |
 | v0.22   | 2021-04-06   | markusthoemmes | evankanderson   | omerbensaadon | 2021-02-24  | 2021-03-30 |
 | v0.23   | 2021-05-18   | tcnghia        | vaikas          | csantanapr    | 2021-04-07  | 2021-05-11 |

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ This roster is seeded with all approvers from Eventing workgroups.
 | v0.19   | 2020-11-10   | julz           | n3wscott        | -             | 2020-09-30  | 2020-11-03 |
 | v0.20   | 2021-01-12   | nak3           | slinkydeveloper | -             | 2020-11-11  | 2021-01-07 |
 | v0.21   | 2021-02-23   | mattmoor       | lionelvillard   | csantanapr    | 2021-01-13  | 2021-02-16 |
-| v0.22   | 2021-04-06   | markusthoemmes | evankanderson   | omerbensaadon | 2021-03-30  | -          |
-| v0.23   | 2021-05-18   | tcnghia        | vaikas          | csantanapr    | 2021-05-11  | -          |
-| v0.24   | 2021-06-29   | dprotaso       | matzew          | julz          | 2021-06-22  | -          |
-| v0.25   | 2021-08-10   | JRBANCEL       | grantr          | automation    | 2021-08-03  | -          |
-| v0.26   | 2021-09-21   | ...            | ...             | automation    | 2021-09-14  | -          |
+| v0.22   | 2021-04-06   | markusthoemmes | evankanderson   | omerbensaadon | 2021-02-24  | 2021-03-30 |
+| v0.23   | 2021-05-18   | tcnghia        | vaikas          | csantanapr    | 2021-04-07  | 2021-05-11 |
+| v0.24   | 2021-06-29   | dprotaso       | matzew          | julz          | 2021-05-19  | 2021-06-22 |
+| v0.25   | 2021-08-10   | JRBANCEL       | grantr          | automation    | 2021-06-30  | 2021-08-03 |
+| v0.26   | 2021-09-21   | ...            | ...             | automation    | 2021-08-11  | 2021-09-14 |
 
 **NOTE:** v0.20 is moved by 3 weeks for end of year holidays
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,26 @@ This roster is seeded with all approvers from Eventing workgroups.
 - slinkydeveloper
 - vaikas
 
+## Docs roster
+
+- csantanapr
+- omerbensaadon
+- julz
+
 ## Schedule
 
-| Release | Release Date | Serving        | Eventing        | Unpin repos | PKG cut    |
-| ------- | ------------ | -------------- | --------------- | ----------- | ---------- |
-| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        | -           | 2020-08-11 |
-| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        | 2020-08-19  | 2020-09-22 |
-| v0.19   | 2020-11-10   | julz           | n3wscott        | 2020-09-30  | 2020-11-03 |
-| v0.20   | 2021-01-12   | nak3           | slinkydeveloper | 2020-11-11  | 2021-01-07 |
-| v0.21   | 2021-02-23   | mattmoor       | lionelvillard   | 2021-01-13  | 2021-02-16 |
-| v0.22   | 2021-04-06   | markusthoemmes | evankanderson   | 2021-02-24  | 2021-03-30 |
-| v0.23   | 2021-05-18   | tcnghia        | vaikas          | 2021-04-07  | 2021-05-11 |
-| v0.24   | 2021-06-29   | dprotaso       | matzew          | 2021-05-19  | 2021-06-22 |
-| v0.25   | 2021-08-10   | JRBANCEL       | grantr          | 2021-06-30  | 2021-08-03 |
-| v0.26   | 2021-09-21   | ...            | ...             | 2021-08-11  | 2021-09-14 |
+| Release | Release Date | Serving        | Eventing        | Docs          | Unpin repos | PKG cut    |
+| ------- | ------------ | -------------- | --------------- | -----------   | ----------- | ---------- |
+| v0.17   | 2020-08-18   | yanweiguo      | Harwayne        | -             | -           | 2020-08-11 |
+| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott        | -             | 2020-08-19  | 2020-09-22 |
+| v0.19   | 2020-11-10   | julz           | n3wscott        | -             | 2020-09-30  | 2020-11-03 |
+| v0.20   | 2021-01-12   | nak3           | slinkydeveloper | -             | 2020-11-11  | 2021-01-07 |
+| v0.21   | 2021-02-23   | mattmoor       | lionelvillard   | csantanapr    | 2021-01-13  | 2021-02-16 |
+| v0.22   | 2021-04-06   | markusthoemmes | evankanderson   | omerbensaadon | 2021-03-30  | -          |
+| v0.23   | 2021-05-18   | tcnghia        | vaikas          | csantanapr    | 2021-05-11  | -          |
+| v0.24   | 2021-06-29   | dprotaso       | matzew          | julz          | 2021-06-22  | -          |
+| v0.25   | 2021-08-10   | JRBANCEL       | grantr          | automation    | 2021-08-03  | -          |
+| v0.26   | 2021-09-21   | ...            | ...             | automation    | 2021-09-14  | -          |
 
 **NOTE:** v0.20 is moved by 3 weeks for end of year holidays
 


### PR DESCRIPTION
adds folks for docs releases 0.23 and 0.24, the goal is to have the process that is fully automated and anyone can cut the release, maybe 1 person to cut just by creating a tag or branch in the docs repo.

