### PR TITLE
Remove website repo from release train

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,6 @@ releases existing. **Skip these**. Special cases are:
 | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [knative.dev/operator](https://github.com/knative/operator) | [![Releases](https://img.shields.io/github/release-pre/knative/operator.svg?sort=semver)](https://github.com/knative/operator/releases) | ![Releasability](https://github.com/knative/operator/workflows/Releasability/badge.svg) | ![Nightly](https://prow.knative.dev/badge.svg?jobs=ci-knative-operator-nightly-release) |
 | [knative.dev/docs](https://github.com/knative/docs)       | N/A      | N/A    | N/A                                                                                   |
-| [knative.dev/website](https://github.com/knative/website)   | N/A                                                                                                                                     | N/A                                                                                     | N/A                                                                                   |
 
 ## Post-release work
 


### PR DESCRIPTION
# Changes

The website repo has been archived, so it's no longer needed as part of the release train.

<img width="162" alt="image" src="https://user-images.githubusercontent.com/44698588/151059690-6c2322a9-c4a7-45e4-b0bc-e242f3f988a0.png">

cc @snneji @csantanapr 