### PR TITLE
Adds reminder to check nightly builds before release day

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,11 @@ channel every morning (5am PST, M-F).
 Announce on **#general** that the release will be cut in a week and that
 additional caution should be used when merging big changes.
 
+### Check nightly builds
+
+Check the status of the nightly builds for each repo. If they are failing,
+reach out the respective WG leads to investigate.
+
 ### Collect release-notes
 
 Make a new HackMD release notes document.
@@ -370,6 +375,11 @@ to run.
 
 Confirm with the respective WG leads that the release is imminent and obtain
 green light.
+
+### Check nightly builds
+
+Check the status of the nightly builds for each repo. If they are failing,
+reach out the respective WG leads to investigate.
 
 ## Day of the release
 


### PR DESCRIPTION
# Changes

Adds items to check the nightly builds at 7 days out and 1 day out as part of the timeline (lesson learned from the 1.2 release).

Fixes #84 

/assign @dprotaso 