### PR TITLE
Add clearer instructions to adding oneself to release lead files in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ https://github.com/knative/community/blob/main/peribolos/knative.yaml and
 https://github.com/knative/community/blob/main/peribolos/knative-sandbox.yaml
 . If not, send a PR like
 [this one](https://github.com/knative/community/pull/209) to grant yourself some
-super power.
+super power. Ensure to run `/hack/update-codegen.sh` to add yourself to the owner
+files as well, as part of the PR.
 
 ### Create a release Slack channel
 


### PR DESCRIPTION
Running `/hack/update-codegen.sh` is needed to pass the `Verify Deps and Codegen` test. This is not listed in the instructions. This should fix that.