### PR TITLE
Extend release schedule through v1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ This roster is seeded with approvers from the Client workgroups.
 | v1.2    | 2022-01-25   | dprotaso       | psschwei            | 2022-01-18 | 2022-01-26
 | v1.3    | 2022-03-08   | carlisia/kvmware | xtreme-sameer-vohra/kvmware | 2022-03-01 | 2022-03-09
 | v1.4    | 2022-04-19   | nader-ziada    | ikvmw               | 2022-04-12 | 2022-04-20
+| v1.5    | 2022-05-31   | yanweiguo      | lionelvillard       | 2022-05-24 | 2022-06-01
+| v1.6    | 2022-07-12   | ZhiminXiang    | evankanderson       | 2022-07-05 | 2022-07-13
+| v1.7    | 2022-08-23   | dprotaso       | matzew              | 2022-08-16 | 2022-08-24
+| v1.8    | 2022-10-04   | nak3           | lionelvillard       | 2022-09-27 | 2022-10-05
+| v1.9    | 2022-11-15   | psschwei       | evankanderson       | 2022-11-08 | 2022-11-16
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ This roster is seeded with approvers from the Client workgroups.
 
 | Release | Release Date | Serving        | Eventing            | PKG cut    | Unpin repos
 | ------- | ------------ | -------------- | --------------------| ---------- | -----------
-| v0.17   | 2020-08-18   | yanweiguo      | Harwayne            | 2020-08-11 | 2020-08-19
-| v0.18   | 2020-09-29   | ZhiminXiang    | n3wscott            | 2020-09-22 | 2020-09-30
-| v0.19   | 2020-11-10   | julz           | n3wscott            | 2020-11-03 | 2020-11-11
 | v0.20   | 2021-01-12   | nak3           | slinkydeveloper     | 2021-01-07 | 2021-01-13
 | v0.21   | 2021-02-23   | mattmoor       | lionelvillard       | 2021-02-16 | 2021-02-24
 | v0.22   | 2021-04-06   | markusthoemmes | evankanderson       | 2021-03-30 | 2021-04-07


### PR DESCRIPTION
# Changes

Added a few more releases to the schedule. Made an educated guess on rotating through people based on recency and who was listed as release lead candidates here. 

Apologies for the mass tag, but wanted to make sure all the serving/eventing approvers had a chance to see this.

@yanweiguo @ZhiminXiang @dprotaso @nak3 @matzew @evankanderson @lionelvillard @aliok @pierDipi  @odacremolbap 