### PR TITLE
Remove client's special step

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ For some repositories some extra manual validation and updates need to be perfor
 
 #### knative/client
 
-* Update the version numbers of Serving and Eventing in [test/presubmit-integration-tests-latest-release.sh](https://github.com/knative/client/blob/main/test/presubmit-integration-tests-latest-release.sh#L20-L21) so that the integration test is already running against the just released serving and eventing versions.
 * (optional) Check that [CHANGELOG.adoc](https://github.com/knative/client/blob/main/CHANGELOG.adoc) contains a section about the release, i.e. the top-level "(Unreleased)" section should be changed to point to the upcoming release version and number. It's not critical if the changelog is aligned after the release in retrospective.
 
 If the validation fails, the fix should be trivial and could be either performed by the release leads or the client team.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

This PR removes client's special step to update versions in E2E test configuration. It's no longer needed. Correct Serving & Eventing version is used per release branch automatically.

# Changes

- :broom: Remove client's special step

/cc @rhuss @knative/knative-release-leads 
