### PR TITLE
Add instructions on updating release schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Currently the following plugins are available with their own formulas:
 * [kn-plugin-quickstart](https://github.com/knative-sandbox/kn-plugin-quickstart/) is managed via `quickstart.rb` formula
 * [kn-plugin-event](https://github.com/knative-sandbox/kn-plugin-event) is managed via `event.rb` formula
 
+### Update release schedule
+
+We maintain a list of current (and future) releases in the [Community repo](https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md). When a new release goes out, an older one will almost always fall out of support. We should update the release schedule accordingly by opening a PR against the community repo. See [here](https://github.com/knative/community/pull/991/files) for an example.
+
 ### Communication 
 
 Announce the release in Knative Slack on the #general and #operations channels.


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Adds post-release step for updating the release schedule in the community repo