### PR TITLE
Adding docs to the release train

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yaml
@@ -58,6 +58,7 @@ body:
       - label: knative.dev/kn-plugin-source-kafka
       - label: knative.dev/kn-plugin-source-kamelet
       - label: knative.dev/kn-plugin-quickstart
+      - label: knative.dev/docs
       - label: Post release - Homebrew tap has been updated
       - label: Post release - The client plugin's Homebrew repo has been updated
       - label: Post release - Release schedule has been updated

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -154,6 +154,60 @@ Use the generated notes to:
 2. ask the relevant WG leads if they have any add or edit for the updated repo notes in the [HackMD document](https://hackmd.io/cJwvzJ4eRVeqqiXzOPtxsA)
 3. use the GitHub UI to update the repo release tag with the final notes
 
+## Releasing a new version of the Knative documentation
+
+To release a new version of the docs you must:
+
+1. [Check dependencies](#check-dependencies)
+1. [Create a release branch](#create-a-release-branch)
+1. [Generate the new docs version](#generate-the-new-docs-version)
+
+### Check dependencies
+
+You cannot release a new version of the docs until the Knative components have
+built their new release.
+This is because the website references these releases in various locations.
+
+Check the following components for the new release:
+
+* [client](https://github.com/knative/client/releases/)
+* [eventing](https://github.com/knative/eventing/releases/)
+* [operator](https://github.com/knative/operator/releases/)
+* [serving](https://github.com/knative/serving/releases/)
+
+### Create a release branch
+
+1. Check on the `#docs` Slack channel to make sure the release is ready.
+_In the future, we should automate this so the check isn't needed._
+
+1. Using the GitHub UI, create a `release-X.Y` branch based on `main`.
+
+  ![branch](https://user-images.githubusercontent.com/35748459/87461583-804c4c80-c5c3-11ea-8105-f9b34988c9af.png)
+
+### Generate the new docs version
+
+To generate the new version of the docs, you must update the [`hack/build.sh`](https://github.com/knative/docs/blob/main/hack/build.sh)
+script in the main branch to reference the new release.
+
+We keep the last 4 releases available per [our support window](https://github.com/knative/community/blob/main/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#knative-community-support-window-principle).
+
+To generate the new docs version:
+
+1. In `hack/build.sh` on the main branch, update `VERSIONS`
+to include the new version, and remove the oldest. Order matters, most recent first.
+
+    For example:
+
+    ```
+    VERSIONS=("1.5" "1.4" "1.3" "1.2")
+    ```
+
+1. PR the result to main.
+
+### How GitHub and Netlify are hooked up
+
+Netlify build is configured via [netlify.toml](https://github.com/knative/docs/blob/main/netlify.toml)
+
 ## Homebrew updates
 ### homebrew-client
 After the client release, the [Homebrew tap](https://github.com/knative/homebrew-client) needs to be updated with the new release:

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -74,7 +74,6 @@ We have a few repos inside of Knative that are not handled in the standard relea
 | Repo   | Release   | Releasability   | Nightly   |
 | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
 | [knative.dev/operator](https://github.com/knative/operator) | [![Releases](https://img.shields.io/github/release-pre/knative/operator.svg?sort=semver)](https://github.com/knative/operator/releases) | [![Releasability](https://github.com/knative/operator/workflows/Releasability/badge.svg)](https://github.com/knative/operator/actions/workflows/knative-releasability.yaml) | [![Nightly](https://prow.knative.dev/badge.svg?jobs=nightly_operator_main_periodic)](https://prow.knative.dev?job=nightly_operator_main_periodic) |
-| [knative.dev/docs](https://github.com/knative/docs)       | N/A      | N/A    | N/A                                                                                   |
 
 ## T-minus zero - releasing core repos
 📝 See instructions for guidance on [Releasing a repository](PROCEDURES.md#releasing-a-repository) and follow all the steps.
@@ -129,5 +128,6 @@ We have a few repos inside of Knative that are not handled in the standard relea
 ## Post-release
 📝 See these instructions for further guidance:
 
+- [Releasing a new version of the Knative documentation](PROCEDURES.md#releasing-a-new-version-of-the-knative-documentation).
 - [Homebrew updates](PROCEDURES.md#homebrew-updates).
 - [Updating the release schedule](PROCEDURES.md#updating-the-release-schedule).


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

# Changes

As discussed in https://github.com/knative/docs/pull/5098#issuecomment-1184475719 , releasing the kra^H^H^H docs can now be done by the release leads. This PR adds instructions on how to do so.

For the docs process:
/assign @csantanapr @snneji 

To verify that the issue automation was done correctly:
@carlisia 