### PR TITLE
Add update knobots update-deps task

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yaml
@@ -18,6 +18,7 @@ body:
       - label: T-minus 30 days - Prior release leads have been removed from rotation
       - label: T-minus 30 days - New release leads have been added for the new rotation
       - label: T-minus 30 days - A new Slack channel for the release has been created
+      - label: T-minus 30 days - Knobots update-deps job has been bumped to new release version
       - label: T-minus 14 days - The releasability defaults have been updated
       - label: T-minus 14 days - The releasability defaults update have been propagated thru all applicable `knative.dev` repos
       - label: T-minus 14 days - An announcement has been made in the **#general** Slack channel that `pkg` will be released in a week

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -251,6 +251,10 @@ If not, open a PR in the `knative/community` repo to grant/remove permissions. H
 
 It is ok to add/remove leads in two separate PRs.
 
+### Bump dependencies in auto update job
+
+In the first week of the rotation, open a PR in the [knobots repo](https://github.com/knative-sandbox/knobots) to bump the [update-deps job](https://github.com/knative-sandbox/knobots/actions/workflows/auto-update-deps.yaml) to the next release version. See [here](https://github.com/knative-sandbox/knobots/pull/216) for an example.
+
 ### Creating a release Slack channel
 Ask someone from the TOC to create a **release-`xdotx`** (Ex: `release-1dot5`) Slack channel that will be used to help manage a new release.
 

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -21,6 +21,7 @@ We release each repository of `knative.dev` every 6 weeks. Please check the [rel
 - 📝 See these instructions for further guidance:
   - [Permissions for release leads](PROCEDURES.md#permissions-for-release-leads).
   - [Creating a release Slack channel](PROCEDURES.md#creating-a-release-slack-channel).
+  - [Bump dependencies in auto-update job](PROCEDURES.md#bump-dependencies-in-auto-update-job).
 
 ## T-minus 14 days
 - Ensure that the releasability defaults have been updated and propagated.


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

<!-- Thanks for sending a pull request! -->

# Changes

Add task to update the knobots update-deps job at the beginning of the release cycle (as noted in https://github.com/knative-sandbox/knobots/pull/216, looks like it was missing from the instructions).

cc @dsimansk 