### PR TITLE
Adding v1.10 to the schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is for Knative release leads who need to track and perform a series
 | v1.7    | 2022-08-23   | dprotaso       | matzew              | 2022-08-16 | 2022-08-24
 | v1.8    | 2022-10-04   | nak3           | lionelvillard       | 2022-09-27 | 2022-10-05
 | v1.9    | 2022-11-15   | psschwei       | evankanderson       | 2022-11-08 | 2022-11-16
+| v1.10    | 2023-01-10   | nader-ziada       | matzew       | 2023-01-03 | 2022-11-16
 
 ## Release leads
 The current pool of Knative release lead volunteers are listed in the [release roster](./ROSTER.md). If you would like to be a Knative release lead, please open a PR to add your name to the list! Please note: Before volunteering to lead a specific release, please look over the [release timeline](TIMELINE.md) to ensure your availability during the various checkpoints for that release is going to be a match.


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Keeping in sync with the RELEASE-SCHEDULE in knative/community, updated in https://github.com/knative/community/pull/1140

(leads for serving/eventing picked based on who looked like they were next up in the cycle)

/assign @nader-ziada @matzew 