### PR TITLE
Add repo release exceptions to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yaml
@@ -48,6 +48,8 @@ body:
       - label: knative.dev/eventing-rabbitmq
       - label: knative.dev/sample-source
       - label: knative.dev/client
+         - (optional) Check that [CHANGELOG.adoc](https://github.com/knative/client/blob/main/CHANGELOG.adoc) contains a section about the release, i.e. the top-level "(Unreleased)" section should be changed to point to the upcoming release version and number. It's not critical if the changelog is aligned after the release in retrospective.
+         - If the validation fails, the fix should be trivial and could be either performed by the release leads or the client team.
       - label: knative.dev/eventing-kafka
       - label: knative.dev/eventing-redis
       - label: knative.dev/eventing-github

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -76,9 +76,6 @@ For some repositories some extra manual validation and updates need to be perfor
   - (optional) Check that [CHANGELOG.adoc](https://github.com/knative/client/blob/main/CHANGELOG.adoc) contains a section about the release, i.e. the top-level "(Unreleased)" section should be changed to point to the upcoming release version and number. It's not critical if the changelog is aligned after the release in retrospective.
   - If the validation fails, the fix should be trivial and could be either performed by the release leads or the client team.
 
-- `knative-sandbox/kn-plugin-quickstart`
-  - Update the version numbers of Serving / Kourier / Eventing in [pkg/install/install.go](https://github.com/knative-sandbox/kn-plugin-quickstart/blob/4e57ed10eaac8882b0a81b2861ddaee37bfcd6f9/pkg/install/install.go#L25-L27) so that the plugin will use the just-released versions.
-
 ### Cutting a branch
 Cutting a `release-x.y` branch can be done by using the GitHub UI:
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

<!-- Thanks for sending a pull request! -->

# Changes

- Add repo release exceptions to issue template
- Removes exception for quickstart, no longer needed after https://github.com/knative-sandbox/kn-plugin-quickstart/pull/327