### PR TITLE
Bump knobots update-deps job at post release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/release-checklist.yaml
@@ -18,7 +18,6 @@ body:
       - label: T-minus 30 days - Prior release leads have been removed from rotation
       - label: T-minus 30 days - New release leads have been added for the new rotation
       - label: T-minus 30 days - A new Slack channel for the release has been created
-      - label: T-minus 30 days - Knobots update-deps job has been bumped to new release version
       - label: T-minus 14 days - The releasability defaults have been updated
       - label: T-minus 14 days - The releasability defaults update have been propagated thru all applicable `knative.dev` repos
       - label: T-minus 14 days - An announcement has been made in the **#general** Slack channel that `pkg` will be released in a week
@@ -68,3 +67,4 @@ body:
       - label: Post release - Release schedule has been updated
       - label: Post release - An announcement was made in the **#general** and **#operation** Slack channels that the new Knative release is out
       - label: Post release - A blog post announcing the release has been published
+      - label: Post release - Knobots update-deps job has been bumped to the next release version


### PR DESCRIPTION
As per title, the following patches are necessary to start pulling the `main` so it should be done after the release:
- https://github.com/knative-sandbox/knobots/pull/230
- https://github.com/knative-sandbox/knobots/pull/245

/cc @dprotaso @lionelvillard 