### PR TITLE
Drop paul from release lead roster

### DIFF
--- a/ROSTER.md
+++ b/ROSTER.md
@@ -15,7 +15,6 @@ This roster is seeded with all approvers from Serving workgroups, plus additiona
 
 - dprotaso
 - nak3
-- psschwei
 - carlisia
 
 ## Eventing


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Due to changes at work, I no longer have the time to serve as a release lead.

