### PR TITLE
Update timeline with release job status badges

### DIFF
--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -70,37 +70,39 @@ The release of the core repos starts on the first day of the release schedule.
 ### Exceptions
 We have a few repos inside of Knative that are not handled in the standard release process at the moment. They might have additional dependencies or depend on the releases existing. **Skip these:**
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/operator](https://github.com/knative/operator) | [![Releases][operator-version-badge]][operator-release-page] | [![Releasability][operator-release-badge]][operator-release-workflow] | [![Nightly][operator-nightly-badge]][operator-nightly-page] |
+| Repo   | Version | Releasability   | Nightly Job   | Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/operator](https://github.com/knative/operator) | [![Releases][operator-version-badge]][operator-release-page] | [![Releasability][operator-release-badge]][operator-release-workflow] | [![Nightly][operator-nightly-badge]][operator-nightly-page] | [![Release][operator-prow-badge]][operator-prow-job] |
 
 ## T-minus zero - releasing core repos
 📝 See instructions for guidance on [Releasing a repository](PROCEDURES.md#releasing-a-repository) and follow all the steps.
 
 ### This group can be started after all the supporting repos have been successfully released.
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/serving](https://github.com/knative/serving) | [![Releases][serving-version-badge]][serving-release-page]  | [![Releasability][serving-release-badge]][serving-release-workflow]  | [![Nightly][serving-nightly-badge]][serving-nightly-page]  |
-| [knative.dev/net-certmanager](https://github.com/knative-sandbox/net-certmanager) | [![Releases][net-certmanager-version-badge]][net-certmanager-release-page]  | [![Releasability][net-certmanager-release-badge]][net-certmanager-release-workflow]  | [![Nightly][net-certmanager-nightly-badge]][net-certmanager-nightly-page]  |
-| [knative.dev/net-contour](https://github.com/knative-sandbox/net-contour) | [![Releases][net-contour-version-badge]][net-contour-release-page]  | [![Releasability][net-contour-release-badge]][net-contour-release-workflow]  | [![Nightly][net-contour-nightly-badge]][net-contour-nightly-page]  |
-| [knative.dev/net-gateway-api](https://github.com/knative-sandbox/net-gateway-api) | [![Releases][net-gateway-api-version-badge]][net-gateway-api-release-page]  | [![Releasability][net-gateway-api-release-badge]][net-gateway-api-release-workflow]  | [![Nightly][net-gateway-api-nightly-badge]][net-gateway-api-nightly-page]  |
-| [knative.dev/net-http01](https://github.com/knative-sandbox/net-http01) | [![Releases][net-http01-version-badge]][net-http01-release-page]  | [![Releasability][net-http01-release-badge]][net-http01-release-workflow]  | [![Nightly][net-http01-nightly-badge]][net-http01-nightly-page]  |
-| [knative.dev/net-istio](https://github.com/knative-sandbox/net-istio) | [![Releases][net-istio-version-badge]][net-istio-release-page]  | [![Releasability][net-istio-release-badge]][net-istio-release-workflow]  | [![Nightly][net-istio-nightly-badge]][net-istio-nightly-page]  |
-| [knative.dev/net-kourier](https://github.com/knative-sandbox/net-kourier) | [![Releases][net-kourier-version-badge]][net-kourier-release-page]  | [![Releasability][net-kourier-release-badge]][net-kourier-release-workflow]  | [![Nightly][net-kourier-nightly-badge]][net-kourier-nightly-page]  |
-| [knative.dev/eventing](https://github.com/knative/eventing) | [![Releases][eventing-version-badge]][eventing-release-page]  | [![Releasability][eventing-release-badge]][eventing-release-workflow]  | [![Nightly][eventing-nightly-badge]][eventing-nightly-page]  |
-| [knative.dev/sample-controller](https://github.com/knative-sandbox/sample-controller) | [![Releases][sample-controller-version-badge]][sample-controller-release-page]  | [![Releasability][sample-controller-release-badge]][sample-controller-release-workflow]  | [![Nightly][sample-controller-nightly-badge]][sample-controller-nightly-page]  |
+| Repo   | Version | Releasability   | Nightly Job   |  Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/serving](https://github.com/knative/serving) | [![Releases][serving-version-badge]][serving-release-page]  | [![Releasability][serving-release-badge]][serving-release-workflow]  | [![Nightly][serving-nightly-badge]][serving-nightly-page]  | [![Release][serving-prow-badge]][serving-prow-job]  |
+| [knative.dev/net-certmanager](https://github.com/knative-sandbox/net-certmanager) | [![Releases][net-certmanager-version-badge]][net-certmanager-release-page]  | [![Releasability][net-certmanager-release-badge]][net-certmanager-release-workflow]  | [![Nightly][net-certmanager-nightly-badge]][net-certmanager-nightly-page]  | [![Release][net-certmanager-prow-badge]][net-certmanager-prow-job]  |
+| [knative.dev/net-contour](https://github.com/knative-sandbox/net-contour) | [![Releases][net-contour-version-badge]][net-contour-release-page]  | [![Releasability][net-contour-release-badge]][net-contour-release-workflow]  | [![Nightly][net-contour-nightly-badge]][net-contour-nightly-page]  | [![Release][net-contour-prow-badge]][net-contour-prow-job]  |
+| [knative.dev/net-gateway-api](https://github.com/knative-sandbox/net-gateway-api) | [![Releases][net-gateway-api-version-badge]][net-gateway-api-release-page]  | [![Releasability][net-gateway-api-release-badge]][net-gateway-api-release-workflow]  | [![Nightly][net-gateway-api-nightly-badge]][net-gateway-api-nightly-page]  | [![Release][net-gateway-api-prow-badge]][net-gateway-api-prow-job]  |
+| [knative.dev/net-http01](https://github.com/knative-sandbox/net-http01) | [![Releases][net-http01-version-badge]][net-http01-release-page]  | [![Releasability][net-http01-release-badge]][net-http01-release-workflow]  | [![Nightly][net-http01-nightly-badge]][net-http01-nightly-page]  | [![Release][net-http01-prow-badge]][net-http01-prow-job]  |
+| [knative.dev/net-istio](https://github.com/knative-sandbox/net-istio) | [![Releases][net-istio-version-badge]][net-istio-release-page]  | [![Releasability][net-istio-release-badge]][net-istio-release-workflow]  | [![Nightly][net-istio-nightly-badge]][net-istio-nightly-page]  | [![Release][net-istio-prow-badge]][net-istio-prow-job]  |
+| [knative.dev/net-kourier](https://github.com/knative-sandbox/net-kourier) | [![Releases][net-kourier-version-badge]][net-kourier-release-page]  | [![Releasability][net-kourier-release-badge]][net-kourier-release-workflow]  | [![Nightly][net-kourier-nightly-badge]][net-kourier-nightly-page]  | [![Release][net-kourier-prow-badge]][net-kourier-prow-job]  |
+| [knative.dev/eventing](https://github.com/knative/eventing) | [![Releases][eventing-version-badge]][eventing-release-page]  | [![Releasability][eventing-release-badge]][eventing-release-workflow]  | [![Nightly][eventing-nightly-badge]][eventing-nightly-page]  | [![Release][eventing-prow-badge]][eventing-prow-job]  |
+| [knative.dev/sample-controller](https://github.com/knative-sandbox/sample-controller) | [![Releases][sample-controller-version-badge]][sample-controller-release-page]  | [![Releasability][sample-controller-release-badge]][sample-controller-release-workflow]  | [![Nightly][sample-controller-nightly-badge]][sample-controller-nightly-page]  | [![Release][sample-controller-prow-badge]][sample-controller-prow-job]  |
+
 
 
 
 ### This group can be started after `knative.dev/eventing` has been successfully published.
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/eventing-ceph](https://github.com/knative-sandbox/eventing-ceph) | [![Releases][eventing-ceph-version-badge]][eventing-ceph-release-page]  | [![Releasability][eventing-ceph-release-badge]][eventing-ceph-release-workflow]  | [![Nightly][eventing-ceph-nightly-badge]][eventing-ceph-nightly-page]  |
-| [knative.dev/eventing-kogito](https://github.com/knative-sandbox/eventing-kogito) | [![Releases][eventing-kogito-version-badge]][eventing-kogito-release-page]  | [![Releasability][eventing-kogito-release-badge]][eventing-kogito-release-workflow]  | [![Nightly][eventing-kogito-nightly-badge]][eventing-kogito-nightly-page]  |
-| [knative.dev/eventing-rabbitmq](https://github.com/knative-sandbox/eventing-rabbitmq) | [![Releases][eventing-rabbitmq-version-badge]][eventing-rabbitmq-release-page]  | [![Releasability][eventing-rabbitmq-release-badge]][eventing-rabbitmq-release-workflow]  | [![Nightly][eventing-rabbitmq-nightly-badge]][eventing-rabbitmq-nightly-page]  |
-| [knative.dev/sample-source](https://github.com/knative-sandbox/sample-source) | [![Releases][sample-source-version-badge]][sample-source-release-page]  | [![Releasability][sample-source-release-badge]][sample-source-release-workflow]  | [![Nightly][sample-source-nightly-badge]][sample-source-nightly-page]  |
+| Repo   | Version | Releasability   | Nightly Job   | Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/eventing-ceph](https://github.com/knative-sandbox/eventing-ceph) | [![Releases][eventing-ceph-version-badge]][eventing-ceph-release-page]  | [![Releasability][eventing-ceph-release-badge]][eventing-ceph-release-workflow]  | [![Nightly][eventing-ceph-nightly-badge]][eventing-ceph-nightly-page]  | [![Release][eventing-ceph-prow-badge]][eventing-ceph-prow-job]  |
+| [knative.dev/eventing-kogito](https://github.com/knative-sandbox/eventing-kogito) | [![Releases][eventing-kogito-version-badge]][eventing-kogito-release-page]  | [![Releasability][eventing-kogito-release-badge]][eventing-kogito-release-workflow]  | [![Nightly][eventing-kogito-nightly-badge]][eventing-kogito-nightly-page]  | [![Release][eventing-kogito-prow-badge]][eventing-kogito-prow-job]  |
+| [knative.dev/eventing-rabbitmq](https://github.com/knative-sandbox/eventing-rabbitmq) | [![Releases][eventing-rabbitmq-version-badge]][eventing-rabbitmq-release-page]  | [![Releasability][eventing-rabbitmq-release-badge]][eventing-rabbitmq-release-workflow]  | [![Nightly][eventing-rabbitmq-nightly-badge]][eventing-rabbitmq-nightly-page]  | [![Release][eventing-rabbitmq-prow-badge]][eventing-rabbitmq-prow-job]  |
+| [knative.dev/sample-source](https://github.com/knative-sandbox/sample-source) | [![Releases][sample-source-version-badge]][sample-source-release-page]  | [![Releasability][sample-source-release-badge]][sample-source-release-workflow]  | [![Nightly][sample-source-nightly-badge]][sample-source-nightly-page]  | [![Release][sample-source-prow-badge]][sample-source-prow-job]  |
+
 
 
 
@@ -108,34 +110,35 @@ We have a few repos inside of Knative that are not handled in the standard relea
 
 Note that `client-pkg` is a supporting library and thus does **NOT** have a release job on Prow.
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/client-pkg](https://github.com/knative/client-pkg) | n/a  | [![Releasability][client-pkg-release-badge]][client-pkg-release-workflow]  | n/a
+| Repo   | Version | Releasability   | Nightly Job   | Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/client-pkg](https://github.com/knative/client-pkg) | n/a  | [![Releasability][client-pkg-release-badge]][client-pkg-release-workflow]  | n/a | n/a
 
 
 ### This group can be started after `knative.dev/client-pkg` has been successfully cut.
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/client](https://github.com/knative/client) | [![Releases][client-version-badge]][client-release-page]  | [![Releasability][client-release-badge]][client-release-workflow]  | [![Nightly][client-nightly-badge]][client-nightly-page]  |
-| [knative.dev/eventing-kafka](https://github.com/knative-sandbox/eventing-kafka) | [![Releases][eventing-kafka-version-badge]][eventing-kafka-release-page]  | [![Releasability][eventing-kafka-release-badge]][eventing-kafka-release-workflow]  | [![Nightly][eventing-kafka-nightly-badge]][eventing-kafka-nightly-page]  |
-| [knative.dev/eventing-redis](https://github.com/knative-sandbox/eventing-redis) | [![Releases][eventing-redis-version-badge]][eventing-redis-release-page]  | [![Releasability][eventing-redis-release-badge]][eventing-redis-release-workflow]  | [![Nightly][eventing-redis-nightly-badge]][eventing-redis-nightly-page]  |
-| [knative.dev/eventing-github](https://github.com/knative-sandbox/eventing-github) | [![Releases][eventing-github-version-badge]][eventing-github-release-page]  | [![Releasability][eventing-github-release-badge]][eventing-github-release-workflow]  | [![Nightly][eventing-github-nightly-badge]][eventing-github-nightly-page]  |
-| [knative.dev/eventing-gitlab](https://github.com/knative-sandbox/eventing-gitlab) | [![Releases][eventing-gitlab-version-badge]][eventing-gitlab-release-page]  | [![Releasability][eventing-gitlab-release-badge]][eventing-gitlab-release-workflow]  | [![Nightly][eventing-gitlab-nightly-badge]][eventing-gitlab-nightly-page]  |
+| Repo   | Version | Releasability   | Nightly Job  | Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/client](https://github.com/knative/client) | [![Releases][client-version-badge]][client-release-page]  | [![Releasability][client-release-badge]][client-release-workflow]  | [![Nightly][client-nightly-badge]][client-nightly-page]  | [![Release][client-prow-badge]][client-prow-job]  |
+| [knative.dev/eventing-kafka](https://github.com/knative-sandbox/eventing-kafka) | [![Releases][eventing-kafka-version-badge]][eventing-kafka-release-page]  | [![Releasability][eventing-kafka-release-badge]][eventing-kafka-release-workflow]  | [![Nightly][eventing-kafka-nightly-badge]][eventing-kafka-nightly-page]  | [![Release][eventing-kafka-prow-badge]][eventing-kafka-prow-job]  |
+| [knative.dev/eventing-redis](https://github.com/knative-sandbox/eventing-redis) | [![Releases][eventing-redis-version-badge]][eventing-redis-release-page]  | [![Releasability][eventing-redis-release-badge]][eventing-redis-release-workflow]  | [![Nightly][eventing-redis-nightly-badge]][eventing-redis-nightly-page]  | [![Release][eventing-redis-prow-badge]][eventing-redis-prow-job]  |
+| [knative.dev/eventing-github](https://github.com/knative-sandbox/eventing-github) | [![Releases][eventing-github-version-badge]][eventing-github-release-page]  | [![Releasability][eventing-github-release-badge]][eventing-github-release-workflow]  | [![Nightly][eventing-github-nightly-badge]][eventing-github-nightly-page]  | [![Release][eventing-github-prow-badge]][eventing-github-prow-job]  |
+| [knative.dev/eventing-gitlab](https://github.com/knative-sandbox/eventing-gitlab) | [![Releases][eventing-gitlab-version-badge]][eventing-gitlab-release-page]  | [![Releasability][eventing-gitlab-release-badge]][eventing-gitlab-release-workflow]  | [![Nightly][eventing-gitlab-nightly-badge]][eventing-gitlab-nightly-page]  | [![Release][eventing-gitlab-prow-badge]][eventing-gitlab-prow-job]  |
+
 
 
 ### This group can be started after all the previous repos have been successfully published.
 
-| Repo   | Release   | Releasability   | Nightly   |
-| ---------------------- | ---------------------- | ---------------------- | ---------------------- |
-| [knative.dev/eventing-kafka-broker](https://github.com/knative-sandbox/eventing-kafka-broker) | [![Releases][eventing-kafka-broker-version-badge]][eventing-kafka-broker-release-page]  | [![Releasability][eventing-kafka-broker-release-badge]][eventing-kafka-broker-release-workflow]  | [![Nightly][eventing-kafka-broker-nightly-badge]][eventing-kafka-broker-nightly-page]  |
-| [knative.dev/eventing-autoscaler-keda](https://github.com/knative-sandbox/eventing-autoscaler-keda) | [![Releases][eventing-autoscaler-keda-version-badge]][eventing-autoscaler-keda-release-page]  | [![Releasability][eventing-autoscaler-keda-release-badge]][eventing-autoscaler-keda-release-workflow]  | [![Nightly][eventing-autoscaler-keda-nightly-badge]][eventing-autoscaler-keda-nightly-page]  |
-| [knative.dev/kn-plugin-admin](https://github.com/knative-sandbox/kn-plugin-admin) | [![Releases][kn-plugin-admin-version-badge]][kn-plugin-admin-release-page]  | [![Releasability][kn-plugin-admin-release-badge]][kn-plugin-admin-release-workflow]  | [![Nightly][kn-plugin-admin-nightly-badge]][kn-plugin-admin-nightly-page]  |
-| [knative.dev/kn-plugin-event](https://github.com/knative-sandbox/kn-plugin-event) | [![Releases][kn-plugin-event-version-badge]][kn-plugin-event-release-page]  | [![Releasability][kn-plugin-event-release-badge]][kn-plugin-event-release-workflow]  | [![Nightly][kn-plugin-event-nightly-badge]][kn-plugin-event-nightly-page]  |
-| [knative.dev/kn-plugin-source-kafka](https://github.com/knative-sandbox/kn-plugin-source-kafka) | [![Releases][kn-plugin-source-kafka-version-badge]][kn-plugin-source-kafka-release-page]  | [![Releasability][kn-plugin-source-kafka-release-badge]][kn-plugin-source-kafka-release-workflow]  | [![Nightly][kn-plugin-source-kafka-nightly-badge]][kn-plugin-source-kafka-nightly-page]  |
-| [knative.dev/kn-plugin-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) | [![Releases][kn-plugin-source-kamelet-version-badge]][kn-plugin-source-kamelet-release-page]  | [![Releasability][kn-plugin-source-kamelet-release-badge]][kn-plugin-source-kamelet-release-workflow]  | [![Nightly][kn-plugin-source-kamelet-nightly-badge]][kn-plugin-source-kamelet-nightly-page]  |
-| [knative.dev/kn-plugin-quickstart](https://github.com/knative-sandbox/kn-plugin-quickstart) | [![Releases][kn-plugin-quickstart-version-badge]][kn-plugin-quickstart-release-page]  | [![Releasability][kn-plugin-quickstart-release-badge]][kn-plugin-quickstart-release-workflow]  | [![Nightly][kn-plugin-quickstart-nightly-badge]][kn-plugin-quickstart-nightly-page]  |
-| [knative.dev/func](https://github.com/knative/func) | [![Releases][func-version-badge]][func-release-page]  | [![Releasability][func-release-badge]][func-release-workflow]  | [![Nightly][func-nightly-badge]][func-nightly-page]  |
+| Repo   | Version | Releasability   | Nightly Job   | Release Job
+| ---------------------- | ---------------------- | ---------------------- | ---------------------- | ---------------------- |
+| [knative.dev/eventing-kafka-broker](https://github.com/knative-sandbox/eventing-kafka-broker) | [![Releases][eventing-kafka-broker-version-badge]][eventing-kafka-broker-release-page]  | [![Releasability][eventing-kafka-broker-release-badge]][eventing-kafka-broker-release-workflow]  | [![Nightly][eventing-kafka-broker-nightly-badge]][eventing-kafka-broker-nightly-page]  | [![Release][eventing-kafka-broker-prow-badge]][eventing-kafka-broker-prow-job]  |
+| [knative.dev/eventing-autoscaler-keda](https://github.com/knative-sandbox/eventing-autoscaler-keda) | [![Releases][eventing-autoscaler-keda-version-badge]][eventing-autoscaler-keda-release-page]  | [![Releasability][eventing-autoscaler-keda-release-badge]][eventing-autoscaler-keda-release-workflow]  | [![Nightly][eventing-autoscaler-keda-nightly-badge]][eventing-autoscaler-keda-nightly-page]  | [![Release][eventing-autoscaler-keda-prow-badge]][eventing-autoscaler-keda-prow-job]  |
+| [knative.dev/kn-plugin-admin](https://github.com/knative-sandbox/kn-plugin-admin) | [![Releases][kn-plugin-admin-version-badge]][kn-plugin-admin-release-page]  | [![Releasability][kn-plugin-admin-release-badge]][kn-plugin-admin-release-workflow]  | [![Nightly][kn-plugin-admin-nightly-badge]][kn-plugin-admin-nightly-page]  | [![Release][kn-plugin-admin-prow-badge]][kn-plugin-admin-prow-job]  |
+| [knative.dev/kn-plugin-event](https://github.com/knative-sandbox/kn-plugin-event) | [![Releases][kn-plugin-event-version-badge]][kn-plugin-event-release-page]  | [![Releasability][kn-plugin-event-release-badge]][kn-plugin-event-release-workflow]  | [![Nightly][kn-plugin-event-nightly-badge]][kn-plugin-event-nightly-page]  | [![Release][kn-plugin-event-prow-badge]][kn-plugin-event-prow-job]  |
+| [knative.dev/kn-plugin-source-kafka](https://github.com/knative-sandbox/kn-plugin-source-kafka) | [![Releases][kn-plugin-source-kafka-version-badge]][kn-plugin-source-kafka-release-page]  | [![Releasability][kn-plugin-source-kafka-release-badge]][kn-plugin-source-kafka-release-workflow]  | [![Nightly][kn-plugin-source-kafka-nightly-badge]][kn-plugin-source-kafka-nightly-page]  | [![Release][kn-plugin-source-kafka-prow-badge]][kn-plugin-source-kafka-prow-job]  |
+| [knative.dev/kn-plugin-source-kamelet](https://github.com/knative-sandbox/kn-plugin-source-kamelet) | [![Releases][kn-plugin-source-kamelet-version-badge]][kn-plugin-source-kamelet-release-page]  | [![Releasability][kn-plugin-source-kamelet-release-badge]][kn-plugin-source-kamelet-release-workflow]  | [![Nightly][kn-plugin-source-kamelet-nightly-badge]][kn-plugin-source-kamelet-nightly-page]  | [![Release][kn-plugin-source-kamelet-prow-badge]][kn-plugin-source-kamelet-prow-job]  |
+| [knative.dev/kn-plugin-quickstart](https://github.com/knative-sandbox/kn-plugin-quickstart) | [![Releases][kn-plugin-quickstart-version-badge]][kn-plugin-quickstart-release-page]  | [![Releasability][kn-plugin-quickstart-release-badge]][kn-plugin-quickstart-release-workflow]  | [![Nightly][kn-plugin-quickstart-nightly-badge]][kn-plugin-quickstart-nightly-page]  | [![Release][kn-plugin-quickstart-prow-badge]][kn-plugin-quickstart-prow-job]  |
+| [knative.dev/func](https://github.com/knative/func) | [![Releases][func-version-badge]][func-release-page]  | [![Releasability][func-release-badge]][func-release-workflow]  | [![Nightly][func-nightly-badge]][func-nightly-page]  | [![Release][func-prow-badge]][func-prow-job]  |
 
 
 ## Post-release
@@ -154,6 +157,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [caching-release-workflow]: https://github.com/knative/release/actions/workflows/knative-caching.yaml
 [caching-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_caching_main_periodic
 [caching-nightly-page]: https://prow.knative.dev?job=nightly_caching_main_periodic
+[caching-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_caching_main_periodic
+[caching-prow-job]: https://prow.knative.dev?job=release_caching_main_periodic
 
 [client-version-badge]: https://img.shields.io/github/release-pre/knative/client.svg?sort=semver
 [client-release-badge]: https://github.com/knative/release/workflows/knative/client/badge.svg
@@ -161,6 +166,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [client-release-workflow]: https://github.com/knative/release/actions/workflows/knative-client.yaml
 [client-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_client_main_periodic
 [client-nightly-page]: https://prow.knative.dev?job=nightly_client_main_periodic
+[client-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_client_main_periodic
+[client-prow-job]: https://prow.knative.dev?job=release_client_main_periodic
 
 [client-pkg-version-badge]: https://img.shields.io/github/release-pre/knative/client-pkg.svg?sort=semver
 [client-pkg-release-badge]: https://github.com/knative/release/workflows/knative/client-pkg/badge.svg
@@ -168,6 +175,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [client-pkg-release-workflow]: https://github.com/knative/release/actions/workflows/knative-client-pkg.yaml
 [client-pkg-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_client-pkg_main_periodic
 [client-pkg-nightly-page]: https://prow.knative.dev?job=nightly_client-pkg_main_periodic
+[client-pkg-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_client-pkg_main_periodic
+[client-pkg-prow-job]: https://prow.knative.dev?job=release_client-pkg_main_periodic
 
 [eventing-version-badge]: https://img.shields.io/github/release-pre/knative/eventing.svg?sort=semver
 [eventing-release-badge]: https://github.com/knative/release/workflows/knative/eventing/badge.svg
@@ -175,6 +184,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-release-workflow]: https://github.com/knative/release/actions/workflows/knative-eventing.yaml
 [eventing-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing_main_periodic
 [eventing-nightly-page]: https://prow.knative.dev?job=nightly_eventing_main_periodic
+[eventing-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing_main_periodic
+[eventing-prow-job]: https://prow.knative.dev?job=release_eventing_main_periodic
 
 [func-version-badge]: https://img.shields.io/github/release-pre/knative/func.svg?sort=semver
 [func-release-badge]: https://github.com/knative/release/workflows/knative/func/badge.svg
@@ -182,6 +193,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [func-release-workflow]: https://github.com/knative/release/actions/workflows/knative-func.yaml
 [func-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_func_main_periodic
 [func-nightly-page]: https://prow.knative.dev?job=nightly_func_main_periodic
+[func-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_func_main_periodic
+[func-prow-job]: https://prow.knative.dev?job=release_func_main_periodic
 
 [networking-version-badge]: https://img.shields.io/github/release-pre/knative/networking.svg?sort=semver
 [networking-release-badge]: https://github.com/knative/release/workflows/knative/networking/badge.svg
@@ -189,6 +202,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [networking-release-workflow]: https://github.com/knative/release/actions/workflows/knative-networking.yaml
 [networking-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_networking_main_periodic
 [networking-nightly-page]: https://prow.knative.dev?job=nightly_networking_main_periodic
+[networking-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_networking_main_periodic
+[networking-prow-job]: https://prow.knative.dev?job=release_networking_main_periodic
 
 [pkg-version-badge]: https://img.shields.io/github/release-pre/knative/pkg.svg?sort=semver
 [pkg-release-badge]: https://github.com/knative/release/workflows/knative/pkg/badge.svg
@@ -196,6 +211,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [pkg-release-workflow]: https://github.com/knative/release/actions/workflows/knative-pkg.yaml
 [pkg-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_pkg_main_periodic
 [pkg-nightly-page]: https://prow.knative.dev?job=nightly_pkg_main_periodic
+[pkg-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_pkg_main_periodic
+[pkg-prow-job]: https://prow.knative.dev?job=release_pkg_main_periodic
 
 [serving-version-badge]: https://img.shields.io/github/release-pre/knative/serving.svg?sort=semver
 [serving-release-badge]: https://github.com/knative/release/workflows/knative/serving/badge.svg
@@ -203,6 +220,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [serving-release-workflow]: https://github.com/knative/release/actions/workflows/knative-serving.yaml
 [serving-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_serving_main_periodic
 [serving-nightly-page]: https://prow.knative.dev?job=nightly_serving_main_periodic
+[serving-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_serving_main_periodic
+[serving-prow-job]: https://prow.knative.dev?job=release_serving_main_periodic
 
 [operator-version-badge]: https://img.shields.io/github/release-pre/knative/operator.svg?sort=semver
 [operator-release-badge]: https://github.com/knative/release/workflows/knative/operator/badge.svg
@@ -210,6 +229,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [operator-release-workflow]: https://github.com/knative/release/actions/workflows/knative-operator.yaml
 [operator-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_operator_main_periodic
 [operator-nightly-page]: https://prow.knative.dev?job=nightly_operator_main_periodic
+[operator-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_operator_main_periodic
+[operator-prow-job]: https://prow.knative.dev?job=release_operator_main_periodic
 
 [control-protocol-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/control-protocol.svg?sort=semver
 [control-protocol-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/control-protocol/badge.svg
@@ -217,6 +238,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [control-protocol-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-control-protocol.yaml
 [control-protocol-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_control-protocol_main_periodic
 [control-protocol-nightly-page]: https://prow.knative.dev?job=nightly_control-protocol_main_periodic
+[control-protocol-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_control-protocol_main_periodic
+[control-protocol-prow-job]: https://prow.knative.dev?job=release_control-protocol_main_periodic
 
 [eventing-autoscaler-keda-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-autoscaler-keda.svg?sort=semver
 [eventing-autoscaler-keda-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-autoscaler-keda/badge.svg
@@ -224,6 +247,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-autoscaler-keda-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-autoscaler-keda.yaml
 [eventing-autoscaler-keda-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-autoscaler-keda_main_periodic
 [eventing-autoscaler-keda-nightly-page]: https://prow.knative.dev?job=nightly_eventing-autoscaler-keda_main_periodic
+[eventing-autoscaler-keda-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-autoscaler-keda_main_periodic
+[eventing-autoscaler-keda-prow-job]: https://prow.knative.dev?job=release_eventing-autoscaler-keda_main_periodic
 
 [eventing-ceph-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-ceph.svg?sort=semver
 [eventing-ceph-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-ceph/badge.svg
@@ -231,6 +256,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-ceph-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-ceph.yaml
 [eventing-ceph-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-ceph_main_periodic
 [eventing-ceph-nightly-page]: https://prow.knative.dev?job=nightly_eventing-ceph_main_periodic
+[eventing-ceph-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-ceph_main_periodic
+[eventing-ceph-prow-job]: https://prow.knative.dev?job=release_eventing-ceph_main_periodic
 
 [eventing-github-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-github.svg?sort=semver
 [eventing-github-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-github/badge.svg
@@ -238,6 +265,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-github-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-github.yaml
 [eventing-github-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-github_main_periodic
 [eventing-github-nightly-page]: https://prow.knative.dev?job=nightly_eventing-github_main_periodic
+[eventing-github-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-github_main_periodic
+[eventing-github-prow-job]: https://prow.knative.dev?job=release_eventing-github_main_periodic
 
 [eventing-gitlab-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-gitlab.svg?sort=semver
 [eventing-gitlab-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-gitlab/badge.svg
@@ -245,6 +274,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-gitlab-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-gitlab.yaml
 [eventing-gitlab-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-gitlab_main_periodic
 [eventing-gitlab-nightly-page]: https://prow.knative.dev?job=nightly_eventing-gitlab_main_periodic
+[eventing-gitlab-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-gitlab_main_periodic
+[eventing-gitlab-prow-job]: https://prow.knative.dev?job=release_eventing-gitlab_main_periodic
 
 [eventing-kafka-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-kafka.svg?sort=semver
 [eventing-kafka-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-kafka/badge.svg
@@ -252,6 +283,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-kafka-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-kafka.yaml
 [eventing-kafka-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-kafka_main_periodic
 [eventing-kafka-nightly-page]: https://prow.knative.dev?job=nightly_eventing-kafka_main_periodic
+[eventing-kafka-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-kafka_main_periodic
+[eventing-kafka-prow-job]: https://prow.knative.dev?job=release_eventing-kafka_main_periodic
 
 [eventing-kafka-broker-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-kafka-broker.svg?sort=semver
 [eventing-kafka-broker-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-kafka-broker/badge.svg
@@ -259,6 +292,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-kafka-broker-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-kafka-broker.yaml
 [eventing-kafka-broker-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-kafka-broker_main_periodic
 [eventing-kafka-broker-nightly-page]: https://prow.knative.dev?job=nightly_eventing-kafka-broker_main_periodic
+[eventing-kafka-broker-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-kafka-broker_main_periodic
+[eventing-kafka-broker-prow-job]: https://prow.knative.dev?job=release_eventing-kafka-broker_main_periodic
 
 [eventing-kogito-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-kogito.svg?sort=semver
 [eventing-kogito-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-kogito/badge.svg
@@ -266,6 +301,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-kogito-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-kogito.yaml
 [eventing-kogito-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-kogito_main_periodic
 [eventing-kogito-nightly-page]: https://prow.knative.dev?job=nightly_eventing-kogito_main_periodic
+[eventing-kogito-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-kogito_main_periodic
+[eventing-kogito-prow-job]: https://prow.knative.dev?job=release_eventing-kogito_main_periodic
 
 [eventing-rabbitmq-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-rabbitmq.svg?sort=semver
 [eventing-rabbitmq-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-rabbitmq/badge.svg
@@ -273,6 +310,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-rabbitmq-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-rabbitmq.yaml
 [eventing-rabbitmq-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-rabbitmq_main_periodic
 [eventing-rabbitmq-nightly-page]: https://prow.knative.dev?job=nightly_eventing-rabbitmq_main_periodic
+[eventing-rabbitmq-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-rabbitmq_main_periodic
+[eventing-rabbitmq-prow-job]: https://prow.knative.dev?job=release_eventing-rabbitmq_main_periodic
 
 [eventing-redis-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/eventing-redis.svg?sort=semver
 [eventing-redis-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/eventing-redis/badge.svg
@@ -280,6 +319,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [eventing-redis-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-eventing-redis.yaml
 [eventing-redis-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_eventing-redis_main_periodic
 [eventing-redis-nightly-page]: https://prow.knative.dev?job=nightly_eventing-redis_main_periodic
+[eventing-redis-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_eventing-redis_main_periodic
+[eventing-redis-prow-job]: https://prow.knative.dev?job=release_eventing-redis_main_periodic
 
 [kn-plugin-admin-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/kn-plugin-admin.svg?sort=semver
 [kn-plugin-admin-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/kn-plugin-admin/badge.svg
@@ -287,6 +328,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [kn-plugin-admin-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-kn-plugin-admin.yaml
 [kn-plugin-admin-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_kn-plugin-admin_main_periodic
 [kn-plugin-admin-nightly-page]: https://prow.knative.dev?job=nightly_kn-plugin-admin_main_periodic
+[kn-plugin-admin-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_kn-plugin-admin_main_periodic
+[kn-plugin-admin-prow-job]: https://prow.knative.dev?job=release_kn-plugin-admin_main_periodic
 
 [kn-plugin-event-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/kn-plugin-event.svg?sort=semver
 [kn-plugin-event-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/kn-plugin-event/badge.svg
@@ -294,6 +337,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [kn-plugin-event-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-kn-plugin-event.yaml
 [kn-plugin-event-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_kn-plugin-event_main_periodic
 [kn-plugin-event-nightly-page]: https://prow.knative.dev?job=nightly_kn-plugin-event_main_periodic
+[kn-plugin-event-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_kn-plugin-event_main_periodic
+[kn-plugin-event-prow-job]: https://prow.knative.dev?job=release_kn-plugin-event_main_periodic
 
 [kn-plugin-quickstart-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/kn-plugin-quickstart.svg?sort=semver
 [kn-plugin-quickstart-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/kn-plugin-quickstart/badge.svg
@@ -301,6 +346,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [kn-plugin-quickstart-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-kn-plugin-quickstart.yaml
 [kn-plugin-quickstart-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_kn-plugin-quickstart_main_periodic
 [kn-plugin-quickstart-nightly-page]: https://prow.knative.dev?job=nightly_kn-plugin-quickstart_main_periodic
+[kn-plugin-quickstart-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_kn-plugin-quickstart_main_periodic
+[kn-plugin-quickstart-prow-job]: https://prow.knative.dev?job=release_kn-plugin-quickstart_main_periodic
 
 [kn-plugin-source-kafka-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/kn-plugin-source-kafka.svg?sort=semver
 [kn-plugin-source-kafka-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/kn-plugin-source-kafka/badge.svg
@@ -308,6 +355,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [kn-plugin-source-kafka-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-kn-plugin-source-kafka.yaml
 [kn-plugin-source-kafka-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_kn-plugin-source-kafka_main_periodic
 [kn-plugin-source-kafka-nightly-page]: https://prow.knative.dev?job=nightly_kn-plugin-source-kafka_main_periodic
+[kn-plugin-source-kafka-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_kn-plugin-source-kafka_main_periodic
+[kn-plugin-source-kafka-prow-job]: https://prow.knative.dev?job=release_kn-plugin-source-kafka_main_periodic
 
 [kn-plugin-source-kamelet-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/kn-plugin-source-kamelet.svg?sort=semver
 [kn-plugin-source-kamelet-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/kn-plugin-source-kamelet/badge.svg
@@ -315,6 +364,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [kn-plugin-source-kamelet-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-kn-plugin-source-kamelet.yaml
 [kn-plugin-source-kamelet-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_kn-plugin-source-kamelet_main_periodic
 [kn-plugin-source-kamelet-nightly-page]: https://prow.knative.dev?job=nightly_kn-plugin-source-kamelet_main_periodic
+[kn-plugin-source-kamelet-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_kn-plugin-source-kamelet_main_periodic
+[kn-plugin-source-kamelet-prow-job]: https://prow.knative.dev?job=release_kn-plugin-source-kamelet_main_periodic
 
 [net-certmanager-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-certmanager.svg?sort=semver
 [net-certmanager-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-certmanager/badge.svg
@@ -322,6 +373,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-certmanager-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-certmanager.yaml
 [net-certmanager-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-certmanager_main_periodic
 [net-certmanager-nightly-page]: https://prow.knative.dev?job=nightly_net-certmanager_main_periodic
+[net-certmanager-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-certmanager_main_periodic
+[net-certmanager-prow-job]: https://prow.knative.dev?job=release_net-certmanager_main_periodic
 
 [net-contour-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-contour.svg?sort=semver
 [net-contour-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-contour/badge.svg
@@ -329,6 +382,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-contour-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-contour.yaml
 [net-contour-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-contour_main_periodic
 [net-contour-nightly-page]: https://prow.knative.dev?job=nightly_net-contour_main_periodic
+[net-contour-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-contour_main_periodic
+[net-contour-prow-job]: https://prow.knative.dev?job=release_net-contour_main_periodic
 
 [net-gateway-api-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-gateway-api.svg?sort=semver
 [net-gateway-api-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-gateway-api/badge.svg
@@ -336,6 +391,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-gateway-api-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-gateway-api.yaml
 [net-gateway-api-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-gateway-api_main_periodic
 [net-gateway-api-nightly-page]: https://prow.knative.dev?job=nightly_net-gateway-api_main_periodic
+[net-gateway-api-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-gateway-api_main_periodic
+[net-gateway-api-prow-job]: https://prow.knative.dev?job=release_net-gateway-api_main_periodic
 
 [net-http01-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-http01.svg?sort=semver
 [net-http01-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-http01/badge.svg
@@ -343,6 +400,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-http01-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-http01.yaml
 [net-http01-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-http01_main_periodic
 [net-http01-nightly-page]: https://prow.knative.dev?job=nightly_net-http01_main_periodic
+[net-http01-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-http01_main_periodic
+[net-http01-prow-job]: https://prow.knative.dev?job=release_net-http01_main_periodic
 
 [net-istio-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-istio.svg?sort=semver
 [net-istio-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-istio/badge.svg
@@ -350,6 +409,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-istio-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-istio.yaml
 [net-istio-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-istio_main_periodic
 [net-istio-nightly-page]: https://prow.knative.dev?job=nightly_net-istio_main_periodic
+[net-istio-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-istio_main_periodic
+[net-istio-prow-job]: https://prow.knative.dev?job=release_net-istio_main_periodic
 
 [net-kourier-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/net-kourier.svg?sort=semver
 [net-kourier-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/net-kourier/badge.svg
@@ -357,6 +418,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [net-kourier-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-net-kourier.yaml
 [net-kourier-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_net-kourier_main_periodic
 [net-kourier-nightly-page]: https://prow.knative.dev?job=nightly_net-kourier_main_periodic
+[net-kourier-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_net-kourier_main_periodic
+[net-kourier-prow-job]: https://prow.knative.dev?job=release_net-kourier_main_periodic
 
 [reconciler-test-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/reconciler-test.svg?sort=semver
 [reconciler-test-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/reconciler-test/badge.svg
@@ -364,6 +427,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [reconciler-test-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-reconciler-test.yaml
 [reconciler-test-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_reconciler-test_main_periodic
 [reconciler-test-nightly-page]: https://prow.knative.dev?job=nightly_reconciler-test_main_periodic
+[reconciler-test-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_reconciler-test_main_periodic
+[reconciler-test-prow-job]: https://prow.knative.dev?job=release_reconciler-test_main_periodic
 
 [sample-controller-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/sample-controller.svg?sort=semver
 [sample-controller-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/sample-controller/badge.svg
@@ -371,6 +436,8 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [sample-controller-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-sample-controller.yaml
 [sample-controller-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_sample-controller_main_periodic
 [sample-controller-nightly-page]: https://prow.knative.dev?job=nightly_sample-controller_main_periodic
+[sample-controller-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_sample-controller_main_periodic
+[sample-controller-prow-job]: https://prow.knative.dev?job=release_sample-controller_main_periodic
 
 [sample-source-version-badge]: https://img.shields.io/github/release-pre/knative-sandbox/sample-source.svg?sort=semver
 [sample-source-release-badge]: https://github.com/knative/release/workflows/knative-sandbox/sample-source/badge.svg
@@ -378,5 +445,7 @@ Note that `client-pkg` is a supporting library and thus does **NOT** have a rele
 [sample-source-release-workflow]: https://github.com/knative/release/actions/workflows/knative-sandbox-sample-source.yaml
 [sample-source-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_sample-source_main_periodic
 [sample-source-nightly-page]: https://prow.knative.dev?job=nightly_sample-source_main_periodic
+[sample-source-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_sample-source_main_periodic
+[sample-source-prow-job]: https://prow.knative.dev?job=release_sample-source_main_periodic
 
 <!-- autogen end -->

--- a/hack/update-timeline-refs.sh
+++ b/hack/update-timeline-refs.sh
@@ -19,6 +19,8 @@ repo_no_prefix=${repo_no_prefix/knative-sandbox\/}
 [${repo_no_prefix}-release-workflow]: https://github.com/knative/release/actions/workflows/${repo/\//-}.yaml
 [${repo_no_prefix}-nightly-badge]: https://prow.knative.dev/badge.svg?jobs=nightly_${repo_no_prefix}_main_periodic
 [${repo_no_prefix}-nightly-page]: https://prow.knative.dev?job=nightly_${repo_no_prefix}_main_periodic
+[${repo_no_prefix}-prow-badge]: https://prow.knative.dev/badge.svg?jobs=release_${repo_no_prefix}_main_periodic
+[${repo_no_prefix}-prow-job]: https://prow.knative.dev?job=release_${repo_no_prefix}_main_periodic
 
 EOF
 done


### PR DESCRIPTION
This is a handy shortcut to access the prow release job for each repo