### PR TITLE
Centralize Release Notes Workflow

### DIFF
--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -1,0 +1,102 @@
+# Copyright 2023 The Knative Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is automagically synced here from github.com/knative-sandbox/knobots
+
+name: 'Release Notes'
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository'
+        required: true
+      branch:
+        description: 'Branch (defaults to latest release branch)'
+        required: false
+      start-rev:
+        description: 'Start Tag (defaults to merge-base(branch, prev-branch))'
+        required: false
+      end-rev:
+        description: 'End Tag (defaults to HEAD of the target branch)'
+        required: false
+
+jobs:
+  release-notes:
+    name: Release Notes
+    runs-on: 'ubuntu-latest'
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.20.x
+
+    - name: Install Dependencies
+      # https://github.com/kubernetes/release/tree/master/cmd/release-notes
+      run: go install k8s.io/release/cmd/release-notes@latest
+
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        # fetch-depth of 0 indicates all history for all branches and tags.
+        fetch-depth: 0
+        repository: ${{ inputs.repo }}
+
+    - name: Generate Notes - ${{ inputs.repo }}
+      run: |
+        set -x
+
+        BRANCHES="$(mktemp)"
+        # List of branches sorted by semver descending
+        git branch -r -l "origin/release-[0-9]*\.[0-9]*" --format="%(refname:lstrip=3)" | sort -Vr > "$BRANCHES"
+
+        # The release-notes tool access ENV vars as options
+        # https://github.com/kubernetes/release/tree/master/cmd/release-notes#options
+        export BRANCH="${{ inputs.branch }}"
+        export ORG=$(echo '${{ inputs.repo }}' | awk -F '/' '{print $1}')
+        export REPO=$(echo '${{ inputs.repo }}' | awk -F '/' '{print $2}')
+
+        echo "ORG=$ORG" >> $GITHUB_ENV
+        echo "REPO=$REPO" >> $GITHUB_ENV
+
+        if [[ -z "$BRANCH" ]]; then
+            BRANCH="$(head -n1 "$BRANCHES")" # Default to last release branch
+        fi
+
+        # If start rev isn't set find the merge base of
+        # the target branch and the previous branch
+        export START_REV="${{ inputs.start-rev }}"
+        if [[ -z "$START_REV" ]]; then
+          if [[ "$BRANCH" == "main" ]]; then
+            LAST_BRANCH="$(head -n1 "$BRANCHES")"
+          else
+            # use grep magic to find the next branch
+            # '-A 1' - prints the line after the match which we can parse
+            LAST_BRANCH="$(grep -A 1 "$BRANCH" "$BRANCHES" | tail -n1)"
+          fi
+
+          export START_SHA="$(git merge-base origin/$LAST_BRANCH origin/$BRANCH)"
+        fi
+
+        export END_REV="${{ inputs.end-rev }}"
+        if [[ -z "$END_REV" ]]; then
+          END_REV="origin/${BRANCH}"
+        fi
+
+        release-notes \
+         --required-author="" \
+         --output=release-notes.md \
+         --repo-path="$PWD" \
+
+    - name: Display Notes
+      run: |
+        cat release-notes.md
+
+    - name: Archive Release Notes
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ORG }}-${{ env.REPO }}-release-notes.md
+        path: release-notes.md

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -106,13 +106,13 @@ jobs:
     - name: Status GO
       run: |
         echo 'SLACK_COLOR=#098e00' >> "$GITHUB_ENV"
-        echo 'SLACK_TITLE=Generated release note' >> "$GITHUB_ENV"
+        echo 'SLACK_TITLE=Release note - ${{ inputs.repo }}@${{ env.BRANCH }}' >> "$GITHUB_ENV"
 
     - name: Status NO-GO
       if: failure()
       run: |
         echo 'SLACK_COLOR=#8E1600' >> "$GITHUB_ENV"
-        echo 'SLACK_TITLE=Generating release note failed' >> "$GITHUB_ENV"
+        echo 'SLACK_TITLE=Release note failed - ${{ inputs.repo }}@${{ env.BRANCH }}' >> "$GITHUB_ENV"
 
     - name: Post status to Slack
       # Note: using env.SLACK_WEBHOOK here because secrets are not allowed in the if block.
@@ -124,7 +124,6 @@ jobs:
         SLACK_ICON: http://github.com/knative.png?size=48
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         MSG_MINIMAL: 'true'
-        SLACK_FOOTER: View GitHub Run - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        SLACK_MESSAGE: |
-          Releate note: [${{ inputs.repo }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+        SLACK_MESSAGE: View - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        SLACK_FOOTER: ""
 

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -33,7 +33,18 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
+        cache: false # installing deps doesn't have a go.sum
         go-version: 1.20.x
+
+    - name: Restore module cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+        key: |
+          ${{ runner.os }}-golang-
+        restore-keys: |
+          ${{ runner.os }}-golang-
 
     - name: Install Dependencies
       # https://github.com/kubernetes/release/tree/master/cmd/release-notes

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -110,6 +110,12 @@ jobs:
         echo "${{ inputs.repo }}@${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
         cat release-notes.md >> $GITHUB_STEP_SUMMARY
 
+    - name: Archive Release Notes
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ORG }}-${{ env.REPO }}-${{ env.BRANCH }}.md
+        path: release-notes.md
+
     - name: Status GO
       run: |
         echo 'SLACK_COLOR=#098e00' >> "$GITHUB_ENV"

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SLACK_WEBHOOK: ${{ secrets.SONAR_TOKEN != '' }}
 
     steps:
     - name: Set up Go
@@ -59,12 +60,13 @@ jobs:
         export ORG=$(echo '${{ inputs.repo }}' | awk -F '/' '{print $1}')
         export REPO=$(echo '${{ inputs.repo }}' | awk -F '/' '{print $2}')
 
-        echo "ORG=$ORG" >> $GITHUB_ENV
-        echo "REPO=$REPO" >> $GITHUB_ENV
-
         if [[ -z "$BRANCH" ]]; then
             BRANCH="$(head -n1 "$BRANCHES")" # Default to last release branch
         fi
+
+        echo "ORG=$ORG" >> $GITHUB_ENV
+        echo "REPO=$REPO" >> $GITHUB_ENV
+        echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
         # If start rev isn't set find the merge base of
         # the target branch and the previous branch
@@ -100,3 +102,29 @@ jobs:
       with:
         name: ${{ env.ORG }}-${{ env.REPO }}-release-notes.md
         path: release-notes.md
+
+    - name: Status GO
+      run: |
+        echo 'SLACK_COLOR=#098e00' >> "$GITHUB_ENV"
+        echo 'SLACK_TITLE=Generated release note' >> "$GITHUB_ENV"
+
+    - name: Status NO-GO
+      if: failure()
+      run: |
+        echo 'SLACK_COLOR=#8E1600' >> "$GITHUB_ENV"
+        echo 'SLACK_TITLE=Generating release note failed' >> "$GITHUB_ENV"
+
+    - name: Post status to Slack
+      # Note: using env.SLACK_WEBHOOK here because secrets are not allowed in the if block.
+      if: ${{ always() && env.SLACK_WEBHOOK != '' }}
+      uses: rtCamp/action-slack-notify@v2.2.0
+      env:
+        SLACK_CHANNEL: knative-release
+        SLACK_USERNAME: knative/release
+        SLACK_ICON: http://github.com/knative.png?size=48
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        MSG_MINIMAL: 'true'
+        SLACK_FOOTER: View GitHub Run - https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        SLACK_MESSAGE: |
+          Releate note: [${{ inputs.repo }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -41,6 +41,7 @@ jobs:
       with:
         path: |
           ~/go/pkg/mod
+          ~/.cache/go-build
         key: |
           ${{ runner.os }}-golang-
         restore-keys: |

--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -106,13 +106,8 @@ jobs:
 
     - name: Display Notes
       run: |
-        cat release-notes.md
-
-    - name: Archive Release Notes
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ env.ORG }}-${{ env.REPO }}-release-notes.md
-        path: release-notes.md
+        echo "${{ inputs.repo }}@${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
+        cat release-notes.md >> $GITHUB_STEP_SUMMARY
 
     - name: Status GO
       run: |


### PR DESCRIPTION
Now instead of going to each repo to create release notes you can do it here

/assign @pradnyavmw 

This also outputs the release notes as a summary - see https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

> Note the caching logic can reduce the run time of the workflow from 8min to 2min