### PR TITLE
fix check owner files workflow

### DIFF
--- a/.github/workflows/check-owners.yaml
+++ b/.github/workflows/check-owners.yaml
@@ -16,7 +16,7 @@ jobs:
     - id: set-matrix
       run: |
         set -x
-        echo "repos=$(yq -o=json -I=0 repos.yaml)" >> $GITHUB_OUTPUT
+        echo "repos=$(yq -o=json -I=0 '[ .[] | .name ]' repos.yaml)" >> $GITHUB_OUTPUT
 
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changing the format of the repos yaml in https://github.com/knative/release/pull/195 broke the check owner aliases workflow