### PR TITLE
Revert "Update releasability action to 1.12 (#250)"

### DIFF
--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -21,7 +21,7 @@ on:
         required: false
 
 env:
-  DEFAULT_RELEASE: "1.12" # make sure this is quoted
+  DEFAULT_RELEASE: "1.11" # make sure this is quoted
   CHECK_MESSAGE: ""
   VERIFY_MESSAGE: ""
 


### PR DESCRIPTION
- Reverts #250 for now to avoid many failures flooding slack.