### PR TITLE
Revert "Revert "Update releasability action to 1.12 (#250)" (#251)"

### DIFF
--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -21,7 +21,7 @@ on:
         required: false
 
 env:
-  DEFAULT_RELEASE: "1.11" # make sure this is quoted
+  DEFAULT_RELEASE: "1.12" # make sure this is quoted
   CHECK_MESSAGE: ""
   VERIFY_MESSAGE: ""
 


### PR DESCRIPTION
- Verified that scheduled workflows will not flood slack only manuals.
- We will update docs.