### PR TITLE
Harmonise release leads table & roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The Knative project releases quarterly, on Tuesday of the 4th week of January, A
 
 ### Release schedule for 2023
 
-| Release | Release Date | Serving             | Eventing                          | Client & Functions | PKG cut    | Unpin repos
-| ------- | ------------ | ------------------- |-----------------------------------|--------------------|------------| -----------
-| v1.11   | 2023-07-25   | skonto, dsimansk    | creydr, pierDipi, Vishal-Chdhry   | dsimansk           | 2023-07-18 | 2023-07-26
-| v1.12   | 2023-10-24   | skonto, ReToCode    | Cali0707, creydr                  | dsimansk           | 2023-10-17 | 2023-10-25
-| v1.13   | 2024-01-23   | TBD                 | TBD                               | TBD                | 2024-01-16 | 2024-01-24
-| v1.14   | 2024-04-25   | TBD                 | TBD                               | TBD                | 2024-04-18 | 2024-04-26
+| Release | Release Date | Release Leads                                     | PKG cut    | Unpin repos |
+|---------|--------------|---------------------------------------------------|------------|-------------|
+| v1.11   | 2023-07-25   | skonto, dsimansk, creydr, pierDipi, Vishal-Chdhry | 2023-07-18 | 2023-07-26  |
+| v1.12   | 2023-10-24   | skonto, ReToCode, Cali0707, creydr, dsimansk      | 2023-10-17 | 2023-10-25  |
+| v1.13   | 2024-01-23   | TBD                                               | 2024-01-16 | 2024-01-24  |
+| v1.14   | 2024-04-25   | TBD                                               | 2024-04-18 | 2024-04-26  |
 
 ## Release leads
 The current pool of Knative release lead volunteers are listed in the [release roster](./ROSTER.md). If you would like to be a Knative release lead, please open a PR to add your name to the list! Please note: Before volunteering to lead a specific release, please look over the [release timeline](TIMELINE.md) to ensure your availability during the various checkpoints for that release is going to be a match.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The Knative project releases quarterly, on Tuesday of the 4th week of January, A
 
 ### Release schedule for 2023
 
-| Release | Release Date | Serving             | Eventing                        | PKG cut    | Unpin repos
-| ------- | ------------ | ------------------- | --------------------------------| ---------- | -----------
-| v1.11   | 2023-07-25   | skonto, dsimansk    | creydr, pierDipi, Vishal-Chdhry | 2023-07-18 | 2023-07-26
-| v1.12   | 2023-10-24   | skonto, ReToCode    | Cali0707, creydr            | 2023-10-17 | 2023-10-25
-| v1.13   | 2024-01-23   | TBD                 | TBD                             | 2024-01-16 | 2024-01-24
-| v1.14   | 2024-04-25   | TBD                 | TBD                             | 2024-04-18 | 2024-04-26
+| Release | Release Date | Serving             | Eventing                          | Client & Functions | PKG cut    | Unpin repos
+| ------- | ------------ | ------------------- |-----------------------------------|--------------------|------------| -----------
+| v1.11   | 2023-07-25   | skonto, dsimansk    | creydr, pierDipi, Vishal-Chdhry   | dsimansk           | 2023-07-18 | 2023-07-26
+| v1.12   | 2023-10-24   | skonto, ReToCode    | Cali0707, creydr                  | dsimansk           | 2023-10-17 | 2023-10-25
+| v1.13   | 2024-01-23   | TBD                 | TBD                               | TBD                | 2024-01-16 | 2024-01-24
+| v1.14   | 2024-04-25   | TBD                 | TBD                               | TBD                | 2024-04-18 | 2024-04-26
 
 ## Release leads
 The current pool of Knative release lead volunteers are listed in the [release roster](./ROSTER.md). If you would like to be a Knative release lead, please open a PR to add your name to the list! Please note: Before volunteering to lead a specific release, please look over the [release timeline](TIMELINE.md) to ensure your availability during the various checkpoints for that release is going to be a match.

--- a/ROSTER.md
+++ b/ROSTER.md
@@ -22,6 +22,7 @@ This roster is seeded with all approvers from Serving workgroups, plus additiona
 
 This roster is seeded with all approvers from Eventing workgroups, plus additional volunteers.
 
+- evankanderson
 - matzew
 - houshengbo
 - Cali0707

--- a/ROSTER.md
+++ b/ROSTER.md
@@ -29,9 +29,9 @@ This roster is seeded with all approvers from Eventing workgroups, plus addition
 - Cali0707
 - creydr
 
-## Client
+## Client & Functions
 
-This roster is seeded with approvers from the Client workgroups.
+This roster is seeded with approvers from the Client and Functions workgroups.
 
 - dsimansk
 - rhuss

--- a/ROSTER.md
+++ b/ROSTER.md
@@ -2,7 +2,7 @@
 
 For each release cycle, we dedicate a team of two individuals, one from Eventing
 and one from Serving, to shepherd the release process. Participation is
-voluntary and based on good faith. Participation is expected to to take place only during local work hours.
+voluntary and based on good faith. Participation is expected to take place only during local work hours.
 
 We seed this rotation with all approvers from all the Serving and Eventing
 workgroups, excluding productivity. If you are no longer active in Knative, or
@@ -22,8 +22,6 @@ This roster is seeded with all approvers from Serving workgroups, plus additiona
 
 This roster is seeded with all approvers from Eventing workgroups, plus additional volunteers.
 
-- evankanderson
-- lionelvillard
 - matzew
 - houshengbo
 - Cali0707
@@ -34,5 +32,3 @@ This roster is seeded with all approvers from Eventing workgroups, plus addition
 This roster is seeded with approvers from the Client and Functions workgroups.
 
 - dsimansk
-- rhuss
-


### PR DESCRIPTION
# Changes
- Add client & functions column to release leads

I think we should have client & functions also on this table, as you folks are always also a part of the release.

/assign @dsimansk 



