### PR TITLE
Add clotributor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ The Knative project releases quarterly, on Tuesday of the 4th week of January, A
 
 ## Release leads
 The current pool of Knative release lead volunteers are listed in the [release roster](./ROSTER.md). If you would like to be a Knative release lead, please open a PR to add your name to the list! Please note: Before volunteering to lead a specific release, please look over the [release timeline](TIMELINE.md) to ensure your availability during the various checkpoints for that release is going to be a match.
+
+## Contributing
+
+If you would like to make contributions towards a future Knative release, you can take a look at all of the help wanted issue across Knative by looking
+at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1).


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README