### PR TITLE
Bump golang to 1.21

### DIFF
--- a/.github/workflows/release-note.yaml
+++ b/.github/workflows/release-note.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         cache: false # installing deps doesn't have a go.sum
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Restore module cache
       uses: actions/cache@v3


### PR DESCRIPTION
# Changes
- Bump golang to 1.21 to fix https://cloud-native.slack.com/archives/C04LY4Y3EHF/p1706120743104309

/assign @skonto 
/assign @dprotaso 