### PR TITLE
:lady_beetle: Use Go1.22 for releaseability checks

### DIFF
--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Install Dependencies
         run: go install knative.dev/toolbox/buoy@main


### PR DESCRIPTION
Use Go1.22 for releaseability checks

# Changes

- :bug: Use Go1.22 for releaseability checks

/kind bug

Fixes https://cloud-native.slack.com/archives/C04LY4Y3EHF/p1721118536234179


